### PR TITLE
Add 1D Riemann solver and analysis updates

### DIFF
--- a/analysis_conservation.py
+++ b/analysis_conservation.py
@@ -10,8 +10,10 @@ if not steps:
     raise SystemExit("No output found")
 
 xs, ys = pp.read_grid("rho")
+is1d = ys is None
 DX = xs[1] - xs[0]
-DY = ys[1] - ys[0]
+if not is1d:
+    DY = ys[1] - ys[0]
 
 def load(step: int, prefix: str) -> np.ndarray:
     return pp.load_field(prefix, step, xs, ys)
@@ -20,8 +22,12 @@ mass=[]; energy=[]
 for s in steps:
     rho = load(s, "rho")
     e   = load(s, "e")
-    mass.append(rho.sum()*DX*DY)
-    energy.append(e.sum()*DX*DY)
+    if is1d:
+        mass.append(rho.sum()*DX)
+        energy.append(e.sum()*DX)
+    else:
+        mass.append(rho.sum()*DX*DY)
+        energy.append(e.sum()*DX*DY)
 
 plt.plot(steps, mass, label='mass')
 plt.plot(steps, energy, label='energy')

--- a/analysis_divergence.py
+++ b/analysis_divergence.py
@@ -10,8 +10,10 @@ if not steps:
     raise RuntimeError("No B field output found. Did you recompile & rerun the solver?")
 
 xs, ys = pp.read_grid("bx")
+is1d = ys is None
 dx = xs[1] - xs[0]
-dy = ys[1] - ys[0]
+if not is1d:
+    dy = ys[1] - ys[0]
 
 def load(step: int, prefix: str) -> np.ndarray:
     return pp.load_field(prefix, step, xs, ys)
@@ -19,11 +21,14 @@ def load(step: int, prefix: str) -> np.ndarray:
 l2 = []
 for s in steps:
     bx = load(s, "bx")
-    by = load(s, "by")
-    div = (np.roll(bx, -1, 1) - np.roll(bx, 1, 1)) / (2 * dx) + (
-        np.roll(by, -1, 0) - np.roll(by, 1, 0)
-    ) / (2 * dy)
-    l2.append(np.sqrt(np.mean(div ** 2)))
+    if is1d:
+        div = (np.roll(bx, -1) - np.roll(bx, 1)) / (2*dx)
+    else:
+        by = load(s, "by")
+        div = (np.roll(bx, -1, 1) - np.roll(bx, 1, 1)) / (2 * dx) + (
+            np.roll(by, -1, 0) - np.roll(by, 1, 0)
+        ) / (2 * dy)
+    l2.append(np.sqrt(np.mean(div**2)))
 
 plt.semilogy(steps,l2,'o-')
 plt.xlabel("step"); plt.ylabel("L2(∇·B)")

--- a/analysis_spectrum.py
+++ b/analysis_spectrum.py
@@ -10,6 +10,9 @@ if not steps:
     raise SystemExit("No velocity output found.")
 
 xs, ys = pp.read_grid("u")
+if ys is None:
+    print("Spectrum analysis skipped for 1D data")
+    raise SystemExit
 nx = len(xs)
 ny = len(ys)
 

--- a/analysis_summary.py
+++ b/analysis_summary.py
@@ -8,9 +8,11 @@ if not steps:
     raise SystemExit("No output found")
 
 xs, ys = pp.read_grid("rho")
+is1d = ys is None
 DX = xs[1] - xs[0]
-DY = ys[1] - ys[0]
-NX, NY = len(xs), len(ys)
+if not is1d:
+    DY = ys[1] - ys[0]
+NX = len(xs)
 
 
 def load(step: int, prefix: str) -> np.ndarray:
@@ -22,13 +24,18 @@ div_l2 = []
 for s in steps:
     rho = load(s, "rho")
     e = load(s, "e")
-    mass.append(rho.sum() * DX * DY)
-    energy.append(e.sum() * DX * DY)
-
-    bx = load(s, "bx")
-    by = load(s, "by")
-    div = (np.roll(bx, -1, 1) - np.roll(bx, 1, 1)) / (2 * DX) + \
-          (np.roll(by, -1, 0) - np.roll(by, 1, 0)) / (2 * DY)
+    if is1d:
+        mass.append(rho.sum() * DX)
+        energy.append(e.sum() * DX)
+        bx = load(s, "bx")
+        div = (np.roll(bx, -1) - np.roll(bx, 1)) / (2 * DX)
+    else:
+        mass.append(rho.sum() * DX * DY)
+        energy.append(e.sum() * DX * DY)
+        bx = load(s, "bx")
+        by = load(s, "by")
+        div = (np.roll(bx, -1, 1) - np.roll(bx, 1, 1)) / (2 * DX) + \
+              (np.roll(by, -1, 0) - np.roll(by, 1, 0)) / (2 * DY)
     div_l2.append(np.sqrt(np.mean(div ** 2)))
 
 print(f"Mass change: {mass[0]:.6g} -> {mass[-1]:.6g}")

--- a/animate_amr.py
+++ b/animate_amr.py
@@ -10,6 +10,9 @@ if not steps:
     raise SystemExit("no output")
 
 xs, ys = pp.read_grid("rho")
+if ys is None:
+    print("Animation skipped for 1D data")
+    raise SystemExit
 X, Y = np.meshgrid(xs, ys)
 
 fig, ax = plt.subplots(figsize=(6,5))

--- a/main.cpp
+++ b/main.cpp
@@ -1,65 +1,177 @@
-#include "solver.hpp"
-#include "physics.hpp"
-#include "io.hpp"
-
-#include <filesystem>
-#include <chrono>
-#include <omp.h>
+#include <cmath>
+#include <vector>
 #include <fstream>
 #include <iostream>
+#include <filesystem>
 #include <iomanip>
-#include <vector>
 
-static std::string prepare_output_dir(){
-    namespace fs = std::filesystem;
-    fs::path base("Result");
-    if(fs::exists(base) && !fs::is_empty(base)){
-        auto ts = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-        fs::rename(base, "Result_"+std::to_string(ts));
+static constexpr double GAMMA = 5.0/3.0;
+static constexpr double CFL   = 0.3;
+static constexpr double CR    = 0.18; // c_p^2 / c_h^2
+
+struct Cell {
+    double rho, u, p, e, bx, by, psi;
+};
+
+struct Flux {
+    double rho, momx, E, Bx, By, psi;
+};
+
+// Fast magnetosonic speed
+static double fast_speed(double rho,double p,double bx,double by){
+    double a2 = GAMMA * p / rho;
+    double b2 = (bx*bx + by*by)/rho;
+    double bx2 = (bx*bx)/rho;
+    double term = std::sqrt(std::max(0.0,(a2 + b2)*(a2 + b2) - 4*a2*bx2));
+    return std::sqrt(0.5*(a2 + b2 + term));
+}
+
+static Flux hll_flux(const Cell& L,const Cell& R,double ch){
+    double B2L = L.bx*L.bx + L.by*L.by;
+    double B2R = R.bx*R.bx + R.by*R.by;
+    double ptL = L.p + 0.5*B2L;
+    double ptR = R.p + 0.5*B2R;
+    double EL = L.p/(GAMMA-1.0) + 0.5*L.rho*L.u*L.u + 0.5*B2L;
+    double ER = R.p/(GAMMA-1.0) + 0.5*R.rho*R.u*R.u + 0.5*B2R;
+
+    double cfL = fast_speed(L.rho,L.p,L.bx,L.by);
+    double cfR = fast_speed(R.rho,R.p,R.bx,R.by);
+    double SL = std::min(L.u - cfL, R.u - cfR);
+    double SR = std::max(L.u + cfL, R.u + cfR);
+
+    Flux F;
+    if(SL>0){
+        F.rho = L.rho * L.u;
+        F.momx = L.rho*L.u*L.u + ptL - L.bx*L.bx;
+        F.E   = (EL + ptL)*L.u - L.bx*(L.u*L.bx);
+        F.Bx  = L.psi;
+        F.By  = L.u*L.by - 0.0*L.bx; // v=0
+        F.psi = ch*ch*L.bx;
+    }else if(SR<0){
+        F.rho = R.rho * R.u;
+        F.momx = R.rho*R.u*R.u + ptR - R.bx*R.bx;
+        F.E   = (ER + ptR)*R.u - R.bx*(R.u*R.bx);
+        F.Bx  = R.psi;
+        F.By  = R.u*R.by - 0.0*R.bx;
+        F.psi = ch*ch*R.bx;
+    }else{
+        double FL_rho = L.rho*L.u;
+        double FR_rho = R.rho*R.u;
+        double FL_momx = L.rho*L.u*L.u + ptL - L.bx*L.bx;
+        double FR_momx = R.rho*R.u*R.u + ptR - R.bx*R.bx;
+        double FL_E = (EL + ptL)*L.u - L.bx*(L.u*L.bx);
+        double FR_E = (ER + ptR)*R.u - R.bx*(R.u*R.bx);
+        double FL_By = L.u*L.by;
+        double FR_By = R.u*R.by;
+        F.rho = (SR*FL_rho - SL*FR_rho + SL*SR*(R.rho - L.rho))/(SR-SL);
+        F.momx = (SR*FL_momx - SL*FR_momx + SL*SR*(R.rho*R.u - L.rho*L.u))/(SR-SL);
+        F.E   = (SR*FL_E - SL*FR_E + SL*SR*(ER-EL))/(SR-SL);
+        F.Bx  = (SR*L.psi - SL*R.psi + SL*SR*(R.bx - L.bx))/(SR-SL);
+        F.By  = (SR*FL_By - SL*FR_By + SL*SR*(R.by - L.by))/(SR-SL);
+        F.psi = ch*ch*(SR*L.bx - SL*R.bx + SL*SR*(R.psi - L.psi))/(SR-SL);
     }
-    fs::create_directory(base);
-    return "Result";
+    return F;
+}
+
+static void write_field(const std::vector<Cell>& U,double x0,double dx,const std::string& prefix,int step){
+    std::ofstream f(prefix+std::to_string(step)+".csv");
+    for(size_t i=1;i<U.size()-1;++i){
+        double x = x0 + (i-1+0.5)*dx;
+        f<<x<<','<<U[i].rho<<','<<U[i].u<<','<<U[i].p<<','<<U[i].bx<<','<<U[i].by<<','<<U[i].psi<<'\n';
+    }
 }
 
 int main(){
-    const int nx=512, ny=512; // higher resolution for peak Bx test
-    const double Lx=1.0, Ly=1.0;
-    const double dx=Lx/(nx-1), dy=Ly/(ny-1);
-    const int max_steps=200;
+    const int nx=1024;
+    const double x0=-0.5,x1=0.5;
+    const double dx=(x1-x0)/nx;
+    const double t_end=0.25;
     const int output_every=20;
+    std::filesystem::create_directory("Result");
 
-    std::string out_dir = prepare_output_dir();
-
-    AMRGrid amr(nx, ny, Lx, Ly, 1); // single level grid
-    FlowField flow(nx,ny,dx,dy);
-    initialize_peak_bx(flow);      // peak Bx initial condition
-    std::vector<FlowField> flows = {flow};
-
-    reset_omp_compute_time();
-    double t0 = omp_get_wtime();
-    for(int step=0; step<=max_steps; ++step){
-        double dt = compute_cfl_timestep(flows[0]);
-
-        solve_MHD(amr, flows, dt, 0.0, 0, 0.0); // full MHD update
-
-        if(step % output_every == 0){
-            auto [max_divB, L1_divB] = compute_divergence_errors(flows[0]);
-            std::cout << "step " << std::setw(4) << step
-                      << " dt=" << dt
-                      << " max_divB=" << max_divB
-                      << " L1_divB=" << L1_divB << "\n";
-            save_flow_MHD(flows[0], out_dir, step);
+    std::vector<Cell> U(nx+2); // ghost cells
+    for(int i=0;i<nx+2;++i){
+        double x = x0 + (i-1+0.5)*dx;
+        Cell c;
+        if(x<0){
+            c.rho=1.0;
+            c.u=10.0;
+            c.by=5.0/std::sqrt(4*M_PI);
+            c.bx=5.0/std::sqrt(4*M_PI);
+            c.p=20.0;
+        }else{
+            c.rho=1.0;
+            c.u=-10.0;
+            c.by=5.0/std::sqrt(4*M_PI);
+            c.bx=5.0/std::sqrt(4*M_PI);
+            c.p=0.0;
         }
+        c.e = c.p/(GAMMA-1.0) + 0.5*c.rho*c.u*c.u + 0.5*(c.bx*c.bx + c.by*c.by);
+        c.psi=0.0;
+        U[i]=c;
     }
-    double t1 = omp_get_wtime();
-    double elapsed = t1 - t0;
-    double omp_elapsed = get_omp_compute_time();
-    std::cout << "Total time " << elapsed << " s (OpenMP " << omp_elapsed << " s)\n";
 
-    std::ofstream time_file(out_dir + "/time.txt");
-    if(time_file.is_open()){
-        time_file << elapsed << "\n";
-        time_file << omp_elapsed << "\n";
+    auto apply_bc=[&](){
+        U[0]=U[1];
+        U[nx+1]=U[nx];
+    };
+    apply_bc();
+
+    double t=0; int step=0;
+    while(t<t_end-1e-12){
+        double max_speed=0.0;
+        for(int i=1;i<=nx;++i){
+            double cf = fast_speed(U[i].rho,U[i].p,U[i].bx,U[i].by);
+            max_speed = std::max(max_speed, std::abs(U[i].u)+cf);
+        }
+        double ch = 1.5*max_speed;
+        max_speed = std::max(max_speed, ch);
+        double dt = CFL*dx/max_speed;
+        if(t+dt>t_end) dt=t_end-t;
+
+        std::vector<Flux> F(nx+1);
+        for(int i=0;i<=nx;i++){
+            F[i]=hll_flux(U[i],U[i+1],ch);
+        }
+        std::vector<Cell> Un(nx+2);
+        for(int i=1;i<=nx;++i){
+            Un[i].rho = U[i].rho - dt/dx*(F[i].rho - F[i-1].rho);
+            double mom = U[i].rho*U[i].u - dt/dx*(F[i].momx - F[i-1].momx);
+            Un[i].bx  = U[i].bx - dt/dx*(F[i].Bx - F[i-1].Bx);
+            Un[i].by  = U[i].by - dt/dx*(F[i].By - F[i-1].By);
+            Un[i].psi = U[i].psi - dt/dx*(F[i].psi - F[i-1].psi);
+            double E  = U[i].e  - dt/dx*(F[i].E   - F[i-1].E);
+            Un[i].u   = mom/Un[i].rho;
+            Un[i].e   = E;
+        }
+        U.swap(Un);
+        apply_bc();
+
+        // GLM divergence cleaning
+        std::vector<Cell> Uc = U;
+        for(int i=1;i<=nx;++i){
+            double divB = (U[i+1].bx - U[i-1].bx)/(2*dx);
+            Uc[i].psi = U[i].psi - dt*(ch*ch*divB + (1.0/CR)*U[i].psi);
+        }
+        for(int i=1;i<=nx;++i){
+            double dpsi_dx = (Uc[i+1].psi - Uc[i-1].psi)/(2*dx);
+            Uc[i].bx = U[i].bx - dt*dpsi_dx;
+        }
+        U.swap(Uc);
+        apply_bc();
+        // update pressure from energy
+        for(int i=1;i<=nx;++i){
+            double B2 = U[i].bx*U[i].bx + U[i].by*U[i].by;
+            double kin = 0.5*U[i].rho*U[i].u*U[i].u;
+            U[i].p = (U[i].e - kin - 0.5*B2)*(GAMMA-1.0);
+            if(U[i].p < 1e-8) U[i].p = 1e-8;
+        }
+
+        t += dt; step++;
+        if(step%output_every==0 || t>=t_end-1e-12){
+            write_field(U,x0,dx,"Result/out_state_",step);
+            std::cout<<"step "<<step<<" t="<<t<<"\n";
+        }
     }
     return 0;
 }

--- a/plot_density.py
+++ b/plot_density.py
@@ -7,15 +7,19 @@ steps = pp.available_steps("rho")
 if not steps:
     raise SystemExit("no rho")
 xs, ys = pp.read_grid("rho")
-nx, ny = len(xs), len(ys)
+is1d = ys is None
+nx = len(xs)
 for s in steps:
     rho = pp.load_field("rho", s, xs, ys)
-    X, Y = np.meshgrid(xs, ys)
-    plt.figure(figsize=(6,5))
-    plt.contourf(X, Y, rho, levels=40, cmap='viridis')
-    plt.colorbar()
+    plt.figure()
+    if is1d:
+        plt.plot(xs, rho)
+        plt.xlabel('x'); plt.ylabel('rho')
+    else:
+        X, Y = np.meshgrid(xs, ys)
+        plt.contourf(X, Y, rho, levels=40, cmap='viridis')
+        plt.gca().set_aspect('equal')
     plt.title(f"rho step {s}")
-    plt.gca().set_aspect('equal')
     out = f"Result/rho_{s}.png"
     plt.savefig(out, dpi=200)
     plt.close()

--- a/postprocess.py
+++ b/postprocess.py
@@ -1,6 +1,6 @@
 import glob
 import re
-from typing import Tuple, List
+from typing import Tuple, List, Optional
 import pandas as pd
 import numpy as np
 
@@ -11,17 +11,22 @@ def available_steps(prefix: str) -> List[int]:
     return sorted(int(re.findall(rf"_{prefix}_(\d+)", f)[0]) for f in files)
 
 
-def read_grid(prefix: str = "rho") -> Tuple[np.ndarray, np.ndarray]:
-    """Read grid coordinates from the first output file."""
+def read_grid(prefix: str = "rho") -> Tuple[np.ndarray, Optional[np.ndarray]]:
+    """Read grid coordinates from the first output file. Works for 1D or 2D."""
     f = glob.glob(f"Result/out_{prefix}_*.csv")[0]
     df = pd.read_csv(f, header=None)
+    if df.shape[1] == 2:
+        xs = df[0].values
+        return xs, None
     xs = np.unique(df[0])
     ys = np.unique(df[1])
     return xs, ys
 
 
-def load_field(prefix: str, step: int, xs: np.ndarray, ys: np.ndarray) -> np.ndarray:
+def load_field(prefix: str, step: int, xs: np.ndarray, ys: Optional[np.ndarray]):
     """Load a field and reshape according to the grid."""
     df = pd.read_csv(f"Result/out_{prefix}_{step}.csv", header=None)
+    if ys is None:
+        return df[1].values
     return df[2].values.reshape(len(xs), len(ys)).T
 

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 mkdir -p build
-g++-14 -O3 -fopenmp *.cpp -o ns2d
+g++ -O3 -fopenmp *.cpp -o riemann1d
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
-./ns2d
+./riemann1d
 
 python3 plot_density.py
 python3 analysis_spectrum.py


### PR DESCRIPTION
## Summary
- replace old 2‑D demo with a 1‑D MHD Riemann problem
- output 1‑D fields and compute GLM divergence cleaning
- adjust Python post‑processing to read both 1‑D and 2‑D data
- make plotting and analysis scripts handle 1‑D runs
- update build/run script for the new solver

## Testing
- `bash run.sh` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_684af2d8850c832ea180bae1ac71ed38